### PR TITLE
Removed unnessary encoding & used consistent quotes

### DIFF
--- a/_angled-edges.scss
+++ b/_angled-edges.scss
@@ -30,13 +30,12 @@
 /// @return {String}  Encoded svg data
 ///
 @function ae-svg-encode($string){
-	$result: ae-str-replace($string, '<svg', "<svg xmlns='http://www.w3.org/2000/svg'");
+	$result: ae-str-replace($string, '<svg', '<svg xmlns="http://www.w3.org/2000/svg"');
 	$result: ae-str-replace($result, '%', '%25');
-	$result: ae-str-replace($result, '"', '%22');
-	$result: ae-str-replace($result, "'", '%27');
-	$result: ae-str-replace($result, ' ', '%20');
+	$result: ae-str-replace($result, '"', '\'');
 	$result: ae-str-replace($result, '<', '%3C');
 	$result: ae-str-replace($result, '>', '%3E');
+
 	@return 'data:image/svg+xml,' + $result;
 }
 
@@ -113,10 +112,10 @@
 			bottom: -$height * 1px;
 		}
 	} @else {
-		@error "Invalid argument for $location - must use: `inside top`, `outside top`, `inside bottom`, `outside bottom`";
+		@error 'Invalid argument for $location - must use: `inside top`, `outside top`, `inside bottom`, `outside bottom`';
 	}
 
 	@if (map-has-key($points, $hypotenuse) == false) {
-		@error "Invalid argument for $hypotenuse - must use: `upper left`, `upper right`, `lower left`, `lower right`";
+		@error 'Invalid argument for $hypotenuse - must use: `upper left`, `upper right`, `lower left`, `lower right`';
 	}
 }


### PR DESCRIPTION
To save bytes & improve legibility, spaces don't need to be encoded and double quotes (`"`) can be converted to single quotes (`'`).

For this input:

``` scss
div {
    @include angled-edge('outside bottom','lower right', red);
}
```

The result is 17 bytes smaller after minification & gzipping:

Old:

``` css
div::after {
  background-image: url("data:image/svg+xml,%3Csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20height=%22100%22%20width=%222800%22%20fill=%22rgb(255,0,0)%22%20fill-opacity=%221%22%3E%3Cpolygon%20points=%220,0%202800,0%200,100%22%3E%3C/polygon%3E%3C/svg%3E");
}
```

New:

``` css
div::after {
  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='100' width='2800' fill='rgb(255,0,0)' fill-opacity='1'%3E%3Cpolygon points='0,0 2800,0 0,100'%3E%3C/polygon%3E%3C/svg%3E");
}
```
